### PR TITLE
chore(ci): add explicit GITHUB_TOKEN permissions to workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   Test-and-Build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,10 @@ name: Deploy
 on:
   push:
     branches: [main]
+
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   Test-and-Build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add explicit top-level `permissions:` blocks to workflow files that were missing them. This follows the principle of least privilege and prepares for GitHub's upcoming enforcement of read-only default `GITHUB_TOKEN` permissions.

## Permissions Applied

| Workflow | Permission | Reason |
|----------|-----------|--------|
| `ci.yaml` | `contents: read` | Only checks out code and runs build/tests — no write access needed |
| `deploy.yml` | `contents: write` | Uses `JamesIves/github-pages-deploy-action` which pushes to `gh-pages` branch via `GITHUB_TOKEN` |
| `lint.yml` | `contents: read` | Only checks out code and runs linting — no write access needed |
| `codeql-analysis.yml` | *(unchanged)* | Already has job-level permissions (`actions: read`, `contents: read`, `security-events: write`) |

## Context

GitHub is moving toward a read-only default for `GITHUB_TOKEN`. Workflows without an explicit `permissions:` block will eventually lose write access unless they opt in. Adding explicit permissions now ensures workflows continue to function correctly after the enforcement date, and reduces the attack surface by granting only the minimum required access.

## Test Plan

- [ ] Verify CI workflow still passes on PRs and pushes to `main`
- [ ] Verify Deploy workflow still successfully deploys to `gh-pages`
- [ ] Verify Lint workflow still passes on PRs and pushes to `main`